### PR TITLE
Enable turbulence in storm2d

### DIFF
--- a/storm2d/storm2d.cxx
+++ b/storm2d/storm2d.cxx
@@ -223,7 +223,6 @@ int STORM2D::init(bool UNUSED(restarting)) {
   }
   
   if (isothermal){
-    T = 1.0 ; 
     SOLVE_FOR2(n,vort) ;
   }
   else{
@@ -258,7 +257,11 @@ int STORM2D::init(bool UNUSED(restarting)) {
 
   // Initialise the fields
   initial_profile("n", n);
-  initial_profile("T", T);  
+  if (isothermal) {
+    T = 1.0;
+  } else {
+    initial_profile("T", T);
+  }
 
   comms.add(n) ;
   if (!isothermal) comms.add(T) ;


### PR DESCRIPTION
Options to add source terms and initial noise in `storm2d`, so that flux-driven turbulence simulations can be run.

Also fixes a bug where `T = 1.0` would be overridden by `initial_profile("T", T)` when running with `isothermal = true`.